### PR TITLE
Update VehicleSearchPlugin for JTL Shop 5.4 support

### DIFF
--- a/VehicleSearchPlugin/Plugin.xml
+++ b/VehicleSearchPlugin/Plugin.xml
@@ -3,8 +3,8 @@
     <name>VehicleSearchPlugin</name>
     <description>Advanced vehicle search with manufacturer, model and type selection</description>
     <author>Bremer Sitzbezüge</author>
-    <version>1.0.0</version>
-    <shopversion>5.0.0</shopversion>
+    <version>1.1.0</version>
+    <shopversion>5.4.0</shopversion>
     <pluginid>VehicleSearchPlugin</pluginid>
     <licence>MIT</licence>
     <link>https://bremer-sitzbezuege.de</link>

--- a/VehicleSearchPlugin/README.md
+++ b/VehicleSearchPlugin/README.md
@@ -27,10 +27,11 @@ Advanced vehicle search plugin with manufacturer, model, and type selection for 
 
 ## Installation
 
-1. Upload the plugin folder to `/plugins/VehicleSearchPlugin/`
-2. Go to JTL Shop Admin → Extensions → Plugin Manager
-3. Find "Vehicle Search Plugin" and click "Install"
-4. Configure settings in Admin → Extensions → Vehicle Search Settings
+1. Zip the contents of this directory so that the archive contains the folder `VehicleSearchPlugin` with the plugin files inside.
+2. Upload the archive through **JTL-Shop 5.4 Plugin Manager** (`Administration → Plugins → Plug-inverwaltung → Hochladen`).
+3. Install the plugin and activate it from the manager.
+4. Configure settings in **Administration → Plugins → Vehicle Search Settings**.
+5. Clear the shop cache so that the new templates and assets are available.
 
 ## Usage
 
@@ -40,11 +41,12 @@ Advanced vehicle search plugin with manufacturer, model, and type selection for 
 {include file='plugins/VehicleSearchPlugin/frontend/templates/vehicle_search.tpl'}
 ```
 
-### In On-Page Composer
+### In On-Page Composer (JTL Shop 5.4)
 
-1. Add a "Rich Text" portlet
-2. Switch to "Source" mode
-3. Add the include statement above
+1. Add a **"Freitext"** portlet to the desired container.
+2. Switch the portlet to **HTML/Quellcode** mode.
+3. Paste the include statement above so that the template is rendered inside the portlet.
+4. Save the page and publish the draft.
 
 ## Configuration
 
@@ -96,7 +98,7 @@ Copy the template file to your theme directory and modify as needed.
 
 ## Requirements
 
-- JTL Shop 5.0.0 or higher
+- JTL Shop 5.4.0 or higher
 - PHP 7.4 or higher
 - MySQL 5.7 or higher
 
@@ -111,6 +113,11 @@ For support and questions, contact:
 MIT License - see LICENSE file for details.
 
 ## Changelog
+
+### Version 1.1.0
+- Declare official compatibility with JTL Shop 5.4.0.
+- Fix AJAX endpoint URLs when the plugin is installed as a packaged plugin.
+- Update asset versioning and documentation to reflect the new release.
 
 ### Version 1.0.0
 - Initial release

--- a/VehicleSearchPlugin/adminmenu/vehicle_search_settings.php
+++ b/VehicleSearchPlugin/adminmenu/vehicle_search_settings.php
@@ -4,7 +4,7 @@
  * 
  * @package VehicleSearchPlugin
  * @author Bremer Sitzbezüge
- * @version 1.0.0
+ * @version 1.1.0
  */
 
 require_once PFAD_ROOT . 'admin/includes/admininclude.php';

--- a/VehicleSearchPlugin/frontend/ajax.php
+++ b/VehicleSearchPlugin/frontend/ajax.php
@@ -4,7 +4,7 @@
  * 
  * @package VehicleSearchPlugin
  * @author Bremer Sitzbezüge
- * @version 1.0.0
+ * @version 1.1.0
  */
 
 require_once PFAD_ROOT . 'includes/globalinclude.php';

--- a/VehicleSearchPlugin/frontend/templates/header.tpl
+++ b/VehicleSearchPlugin/frontend/templates/header.tpl
@@ -1,2 +1,2 @@
 {* Vehicle Search Plugin Header Assets *}
-<link rel="stylesheet" href="{$pluginUrl}frontend/css/vehicle-search.css?v=1.0.0">
+<link rel="stylesheet" href="{$pluginUrl}frontend/css/vehicle-search.css?v=1.1.0">

--- a/VehicleSearchPlugin/frontend/templates/vehicle_search.tpl
+++ b/VehicleSearchPlugin/frontend/templates/vehicle_search.tpl
@@ -136,7 +136,7 @@ document.addEventListener('DOMContentLoaded', function() {
         formData.append('action', 'getManufacturers');
         formData.append('csrf_token', document.querySelector('input[name="csrf_token"]').value);
         
-        fetch('{$PluginUrl}ajax.php', {
+        fetch('{$pluginUrl}frontend/ajax.php', {
             method: 'POST',
             body: formData,
             headers: {
@@ -163,7 +163,7 @@ document.addEventListener('DOMContentLoaded', function() {
         formData.append('manufacturer_id', manufacturerId);
         formData.append('csrf_token', document.querySelector('input[name="csrf_token"]').value);
         
-        fetch('{$PluginUrl}ajax.php', {
+        fetch('{$pluginUrl}frontend/ajax.php', {
             method: 'POST',
             body: formData,
             headers: {
@@ -192,7 +192,7 @@ document.addEventListener('DOMContentLoaded', function() {
         formData.append('model_name', modelName);
         formData.append('csrf_token', document.querySelector('input[name="csrf_token"]').value);
         
-        fetch('{$PluginUrl}ajax.php', {
+        fetch('{$pluginUrl}frontend/ajax.php', {
             method: 'POST',
             body: formData,
             headers: {
@@ -220,7 +220,7 @@ document.addEventListener('DOMContentLoaded', function() {
         formData.append('action', 'getCategories');
         formData.append('csrf_token', document.querySelector('input[name="csrf_token"]').value);
         
-        fetch('{$PluginUrl}ajax.php', {
+        fetch('{$pluginUrl}frontend/ajax.php', {
             method: 'POST',
             body: formData,
             headers: {

--- a/VehicleSearchPlugin/includes/VehicleSearchPlugin.php
+++ b/VehicleSearchPlugin/includes/VehicleSearchPlugin.php
@@ -4,7 +4,7 @@
  * 
  * @package VehicleSearchPlugin
  * @author Bremer Sitzbezüge
- * @version 1.0.0
+ * @version 1.1.0
  */
 
 class VehicleSearchPlugin extends Plugin
@@ -17,7 +17,7 @@ class VehicleSearchPlugin extends Plugin
     /**
      * Plugin version
      */
-    const VERSION = '1.0.0';
+    const VERSION = '1.1.0';
     
     /**
      * Configuration cache


### PR DESCRIPTION
## Summary
- declare compatibility with JTL Shop 5.4.0 and bump the plugin version to 1.1.0
- refresh the installation and On-Page Composer instructions for the packaged plugin workflow
- fix AJAX endpoint URLs to use the plugin path when installed and update asset cache-busting strings

## Testing
- php -l VehicleSearchPlugin/includes/VehicleSearchPlugin.php
- php -l VehicleSearchPlugin/frontend/ajax.php
- php -l VehicleSearchPlugin/adminmenu/vehicle_search_settings.php

------
https://chatgpt.com/codex/tasks/task_e_68dd468c0ccc832dbc0829948b353530